### PR TITLE
Melhoria no botão de transcrição de textos

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,15 +2,17 @@
   <div class="wrapper-app wrapper-app__full">
     <router-view />
     <pounds-translator />
+    <audio-button />
   </div>
 </template>
 
 
 <script>
+  import AudioButton from "./commons/components/AudioButton";
   import PoundsTranslator from "./commons/components/PoundsTranslator";
 export default {
   name: "App",
-  components: {PoundsTranslator}
+  components: { AudioButton, PoundsTranslator }
 };
 </script>
 

--- a/src/assets/scss/base/_typography.scss
+++ b/src/assets/scss/base/_typography.scss
@@ -2,6 +2,10 @@ html, body, pre, code, kbd, samp {
     font-family: 'Press Start 2P', sans-serif;
 }
 
+h1, h2, h3, h4, h5, h6, p, span, label, a, button {
+    user-select: all;
+}
+
 .title {
     font-size: 1.6rem;
 

--- a/src/assets/scss/base/_utilities.scss
+++ b/src/assets/scss/base/_utilities.scss
@@ -8,5 +8,8 @@
 .margin-bottom-1 { margin-bottom: 1rem; }
 .margin-bottom-2 { margin-bottom: 2rem; }
 
+.padding-left-2 { padding-left: 2rem; }
+.padding-right-2 { padding-right: 2rem; }
+
 .left { float: left; }
 .right { float: right; }

--- a/src/assets/scss/components/_audio-button.scss
+++ b/src/assets/scss/components/_audio-button.scss
@@ -1,0 +1,20 @@
+.audio-button {
+    position: fixed;
+    max-width: 95vw;
+    right: 0;
+    top: 60%;
+    margin-top: calc(6rem - 32vh);
+
+    padding: 6px;
+    border-radius: 12px;
+    border: none;
+
+    background: #8e69d3;  /* fallback for old browsers */
+background: -webkit-linear-gradient(to right, #9331e4, #8e69d3);  /* Chrome 10-25, Safari 5.1-6 */
+background: linear-gradient(to right, #9331e4, #8e69d3); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+
+
+    & svg {
+        color: var(--color-white);
+    }
+}

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -8,6 +8,7 @@
 @import "base/utilities";
 
 @import "components/alert";
+@import "components/audio-button";
 @import "components/bottom-navigation";
 @import "components/carousel";
 @import "components/class-card";

--- a/src/commons/components/Alert.vue
+++ b/src/commons/components/Alert.vue
@@ -1,24 +1,19 @@
 <template>
   <modal :name="id" width="80%" height="auto" classes="nes-container is-rounded alert">
     <i v-if="octocat" class="nes-octocat animate"></i>
-    <form id="form-text" method="dialog">
+    <form method="dialog">
       <h3 class="title">{{title}}</h3>
       <p class="subtitle margin-bottom-2">{{message}}</p>
       <menu class="dialog-menu">
         <button class="nes-btn" @click="hideAlert">{{confirmMessage}}</button>
       </menu>
-      <br />
-      <audio-button :tagId="'form-text'" />
     </form>
   </modal>
 </template>
 
 <script>
-import AudioButton from "@/commons/components/AudioButton";
-
 export default {
   name: "alert",
-  components: { AudioButton },
   props: {
     confirmMessage: {
       type: String,

--- a/src/commons/components/AudioButton.vue
+++ b/src/commons/components/AudioButton.vue
@@ -6,7 +6,7 @@
     <alert
       id="audio-button"
       title="Instruções de uso do áudio"
-      message="Para utilizar o recurso de áudio na aplicação, apenas selecione os textos que deseja ouvir."
+      message="Para utilizar o recurso de áudio na aplicação, selecione os textos que deseja ouvir."
       confirmMessage="Confirmar"
     />
   </div>

--- a/src/commons/components/AudioButton.vue
+++ b/src/commons/components/AudioButton.vue
@@ -1,14 +1,24 @@
 <template>
-  <button class="nes-btn is-primary" @click="falarTexto()">
-    <font-awesome-icon size="lg" :icon="icons.faVolumeUp"/>
-  </button>
+  <div>
+    <button class="audio-button" @click="openModal">
+      <font-awesome-icon size="lg" :icon="icons.faVolumeUp"/>
+    </button>
+    <alert
+      id="audio-button"
+      title="Intruções de uso do áudio"
+      message="Para utilizar os recursos de áudio na aplicação, selecione os textos que deseja ouvir."
+      confirmMessage="Confirmar"
+    />
+  </div>
 </template>
 
 <script>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faVolumeUp } from '@fortawesome/free-solid-svg-icons'
+import Alert from '@/commons/components/Alert'
+
 export default {
-  components: { FontAwesomeIcon },
+  components: { FontAwesomeIcon, Alert },
   data() {
       return {
           icons: {
@@ -23,14 +33,14 @@ export default {
     }
   },
   mounted() {
-    this.configurarIdiomaApiAudio();
+    this.setupLanguageAudioAPI();
   },
   methods: {
-    configurarIdiomaApiAudio() {
+    setupLanguageAudioAPI() {
       responsiveVoice.setDefaultVoice("Brazilian Portuguese Female");
     },
-    falarTexto() {
-      responsiveVoice.speak(document.getElementById(this.tagId).textContent);
+    openModal() {
+      this.$modal.show("audio-button");
     }
   }
 };

--- a/src/commons/components/AudioButton.vue
+++ b/src/commons/components/AudioButton.vue
@@ -6,7 +6,7 @@
     <alert
       id="audio-button"
       title="Instruções de uso do áudio"
-      message="Para utilizar o recurso de áudio na aplicação, selecione os textos que deseja ouvir."
+      message="Para utilizar o recurso de áudio na aplicação, selecione manualmente os textos que deseja ouvir."
       confirmMessage="Confirmar"
     />
   </div>

--- a/src/commons/components/AudioButton.vue
+++ b/src/commons/components/AudioButton.vue
@@ -5,8 +5,8 @@
     </button>
     <alert
       id="audio-button"
-      title="Intruções de uso do áudio"
-      message="Para utilizar os recursos de áudio na aplicação, selecione os textos que deseja ouvir."
+      title="Instruções de uso do áudio"
+      message="Para utilizar o recurso de áudio na aplicação, apenas selecione os textos que deseja ouvir."
       confirmMessage="Confirmar"
     />
   </div>

--- a/src/commons/components/AudioButton.vue
+++ b/src/commons/components/AudioButton.vue
@@ -1,9 +1,21 @@
 <template>
-  <i style="cursor: pointer" class="nes-icon youtube is-medium" @click="falarTexto()"></i>
+  <button class="nes-btn is-primary" @click="falarTexto()">
+    <font-awesome-icon size="lg" :icon="icons.faVolumeUp"/>
+  </button>
 </template>
 
 <script>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faVolumeUp } from '@fortawesome/free-solid-svg-icons'
 export default {
+  components: { FontAwesomeIcon },
+  data() {
+      return {
+          icons: {
+              faVolumeUp
+          }
+      }
+  },
   props: {
     tagId: {
       type: String,

--- a/src/views/external/greetings/Greetings.vue
+++ b/src/views/external/greetings/Greetings.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="container center-text">
-    <div class="margin-bottom-2 carousel">
+    <div class="margin-bottom-2 carousel padding-left-2 padding-right-2">
       <greetings-carousel />
     </div>
     <router-link to="signin" class="nes-btn is-success">Jogar</router-link>

--- a/src/views/external/greetings/components/GreetingsCarousel.vue
+++ b/src/views/external/greetings/components/GreetingsCarousel.vue
@@ -1,5 +1,5 @@
 <template>
-  <carousel :perPage="1" :autoplayTimeout="6000" autoplay>
+  <carousel :navigationEnabled="true" :perPage="1" :autoplayTimeout="60000" autoplay>
     <slide>
       <section>
         <i class="nes-octocat animate"></i>

--- a/src/views/external/greetings/components/GreetingsCarousel.vue
+++ b/src/views/external/greetings/components/GreetingsCarousel.vue
@@ -4,46 +4,39 @@
       <section>
         <i class="nes-octocat animate"></i>
         <h3 class="title">Game</h3>
-        <p
-          id="slide-1"
-          class="subtitle"
-        >Seja bem-vindo ao Game! Nós temos muitas aventuras pela frente...</p>
-        <audio-button :tagId="'slide-1'" />
+        <p class="subtitle">Seja bem-vindo ao Game! Nós temos muitas aventuras pela frente...</p>
       </section>
     </slide>
     <slide>
       <section>
         <i class="nes-icon is-large like"></i>
         <h3 class="title">Viva uma aventura!</h3>
-        <p id="slide-2" class="subtitle">
+        <p class="subtitle">
           Convide os seus amigos e professores para viverem aventuras incríveis
-          em uma cidade enqunto exercitam os seus conhecimentos adquiridos em
+          em uma cidade enquanto exercitam os seus conhecimentos adquiridos em
           aula.
         </p>
-        <audio-button :tagId="'slide-2'" />
       </section>
     </slide>
     <slide>
       <section>
         <i class="nes-icon trophy is-large"></i>
         <h3 class="title">Conquiste troféus!</h3>
-        <p id="slide-3" class="subtitle">
+        <p class="subtitle">
           Desafie e seja desafiado! Conquiste prémios e troféus de acordo com o
           seu rendimento nas fases e exercícios.
         </p>
-        <audio-button :tagId="'slide-3'" />
       </section>
     </slide>
     <slide>
       <section>
         <i class="nes-icon is-large star"></i>
         <h3 class="title">Exercite!</h3>
-        <p id="slide-4" class="subtitle">
+        <p class="subtitle">
           Seja capaz de associar problemas do cotidiano de uma cidade com
           conteúdos aprendidos em sala de aula. Pressione o botão "Jogar" para
           começar agora mesmo.
         </p>
-        <audio-button :tagId="'slide-4'" />
       </section>
     </slide>
   </carousel>
@@ -51,15 +44,9 @@
 
 <script>
 import { Carousel, Slide } from "vue-carousel";
-import AudioButton from "@/commons/components/AudioButton";
 
 export default {
   name: "greetings-carousel",
-  components: { AudioButton, Carousel, Slide },
-  methods: {
-    falar(p) {
-      responsiveVoice.speak(document.getElementById(p).textContent);
-    }
-  }
+  components: { Carousel, Slide }
 };
 </script>

--- a/src/views/external/reset/ResetPassword.vue
+++ b/src/views/external/reset/ResetPassword.vue
@@ -2,10 +2,9 @@
     <section class="container">
         <div class="center-text">
             <h3 class="title">Redefinir senha</h3>
-            <p id="reset-password-text" class="subtitle">
+            <p class="subtitle">
                 Para redefinir sua senha, insira um endereço de e-mail válido e clique em "Redefinir". Caso deseje voltar, pressione a opção "Voltar".
             </p>
-            <audio-button :tagId="'reset-password-text'" />
         </div>
         <reset-password-form-actions
                 @resetPassword="resetPassword"
@@ -17,13 +16,12 @@
 <script>
     import actionTypes from "@/commons/constants/action-types";
     import Alert from "@/commons/components/Alert";
-    import AudioButton from "@/commons/components/AudioButton";
     import ResetPasswordFormActions from "./components/ResetPasswordFormActions";
     import getMessageError from "@/globals/utils/getMessageError.js";
 
     export default {
         name: 'reset-password',
-        components: {Alert, AudioButton, ResetPasswordFormActions},
+        components: {Alert, ResetPasswordFormActions},
         data() {
             return {
                 info: {

--- a/src/views/external/signin/Signin.vue
+++ b/src/views/external/signin/Signin.vue
@@ -2,11 +2,7 @@
   <section class="container">
     <div class="center-text">
       <h3 class="title">Autenticar-se</h3>
-      <p
-        id="intro-auth"
-        class="subtitle"
-      >Para começar, efetue autenticação ou crie uma nova conta na opção "Criar nova conta".</p>
-      <audio-button :tagId="'intro-auth'" />
+      <p class="subtitle">Para começar, efetue autenticação ou crie uma nova conta na opção "Criar nova conta".</p>
     </div>
     <form @submit.prevent="signin">
       <signin-inputs v-model="user" />
@@ -19,7 +15,6 @@
 <script>
 import SigninInputs from "./components/SigninInputs";
 import SigninActions from "./components/SigninActions";
-import AudioButton from "@/commons/components/AudioButton";
 import Alert from "@/commons/components/Alert";
 
 import getMessageError from "@/globals/utils/getMessageError.js";
@@ -27,7 +22,7 @@ import actionTypes from "@/commons/constants/action-types";
 
 export default {
   name: "signin",
-  components: { AudioButton, Alert, SigninInputs, SigninActions },
+  components: { Alert, SigninInputs, SigninActions },
   data() {
     return {
       user: {

--- a/src/views/external/signup/Signup.vue
+++ b/src/views/external/signup/Signup.vue
@@ -2,11 +2,9 @@
   <section class="container">
     <div class="center-text">
       <h3 class="title">Criar nova conta</h3>
-      <p
-        id="signup-text"
-        class="subtitle"
-      >Para criar uma conta, insira suas informações nos campos abaixo e confirme. Caso deseje fazer autenticação, pressione a opção "Voltar".</p>
-      <audio-button :tagId="'signup-text'" />
+      <p class="subtitle">
+        Para criar uma conta, insira suas informações nos campos abaixo e confirme. Caso deseje fazer autenticação, pressione a opção "Voltar".
+      </p>
     </div>
     <form @submit.prevent="signup">
       <signup-inputs v-model="user" />
@@ -19,7 +17,6 @@
 <script>
 import SignupInputs from "./components/SignupInputs";
 import SignupActions from "./components/SignupActions";
-import AudioButton from "@/commons/components/AudioButton";
 import Alert from "@/commons/components/Alert";
 
 import firebase from "firebase";
@@ -28,7 +25,7 @@ import getMessageError from "@/globals/utils/getMessageError.js";
 
 export default {
   name: "signup",
-  components: { AudioButton, Alert, SignupInputs, SignupActions },
+  components: { Alert, SignupInputs, SignupActions },
   data() {
     return {
       user: {

--- a/src/views/internal/student/class/add/ClassAdd.vue
+++ b/src/views/internal/student/class/add/ClassAdd.vue
@@ -2,10 +2,9 @@
   <section class="container">
     <div class="center-text">
       <h3 class="title">Ingressar em uma nova classe</h3>
-      <p id="enter-class" class="subtitle">
+      <p class="subtitle">
         Para ingressar uma nova classe, leia o código QR Code ou digite o código manualmente no campo abaixo.
       </p>
-      <audio-button class="margin-bottom-2" :tagId="'enter-class'" />
     </div>
     <form @submit.prevent="add(classContent.code)">
       <class-form-inputs v-model="classContent" />
@@ -18,7 +17,6 @@
 <script>
   import AbstractClassAddVue from "./AbstractClassAdd.vue";
   import Alert from "@/commons/components/Alert";
-  import AudioButton from "@/commons/components/AudioButton";
   import ClassFormActions from "./components/ClassFormActions";
   import ClassFormInputs from "./components/ClassFormInputs";
 
@@ -27,7 +25,6 @@
     extends: AbstractClassAddVue,
     components: {
       Alert,
-      AudioButton,
       ClassFormActions,
       ClassFormInputs
     }

--- a/src/views/internal/student/class/classroom/ClassRoom.vue
+++ b/src/views/internal/student/class/classroom/ClassRoom.vue
@@ -4,7 +4,7 @@
             <loading/>
         </div>
         <div v-else>
-            <div id="class-description" class="margin-bottom-2 center-text">
+            <div class="margin-bottom-2 center-text">
                 <a href="#" class="nes-badge center-box margin-bottom-1">
                     <span class="is-dark">{{classFound.name}}</span>
                 </a>
@@ -13,9 +13,6 @@
             </div>
             <div>
                 <class-room-teacher-card v-model="teacher" />
-            </div>
-            <div class="center-button">
-                <audio-button style="margin-top: 20px" :tagId="'class-description'" />
             </div>
         </div>
     </class-wrapper>
@@ -26,13 +23,12 @@ import {mapMutations} from 'vuex'
 import Loading from "@/commons/components/Loading";
 import actionTypes from "@/commons/constants/action-types";
 import mutationTypes from "@/commons/constants/mutation-types";
-import AudioButton from "@/commons/components/AudioButton";
 import ClassWrapper from "../commons/ClassWrapper";
 import ClassRoomTeacherCard from "./components/ClassRoomTeacherCard";
 
 export default {
     name: "class-room",
-    components: { AudioButton, ClassRoomTeacherCard, ClassWrapper, Loading },
+    components: { ClassRoomTeacherCard, ClassWrapper, Loading },
     data() {
         return {
             uid: "",

--- a/src/views/internal/student/class/exercises/ClassExercises.vue
+++ b/src/views/internal/student/class/exercises/ClassExercises.vue
@@ -4,7 +4,7 @@
       <a href="#" class="nes-badge center-box margin-bottom-1">
         <span class="is-primary">Desafios</span>
       </a>
-      <p id="list-exercises" class="subtitle">Lista de desafios para resolver.</p>
+      <p class="subtitle">Lista de desafios para resolver.</p>
     </div>
     <div class="flex">
       <class-exercises-card
@@ -13,20 +13,16 @@
         v-bind:key="item.index"
       />
     </div>
-    <div style="margin-top: 10px" class="center-button">
-      <audio-button  :tagId="'list-exercises'" />
-    </div>
   </class-wrapper>
 </template>
 
 <script>
-import AudioButton from "@/commons/components/AudioButton";
 import ClassWrapper from "../commons/ClassWrapper";
 import ClassExercisesCard from "./components/ClassExercisesCard";
 
 export default {
   name: "class-exercises",
-  components: { AudioButton, ClassWrapper, ClassExercisesCard },
+  components: { ClassWrapper, ClassExercisesCard },
   data() {
     return {
       exercises: [

--- a/src/views/internal/student/class/ranking/ClassRanking.vue
+++ b/src/views/internal/student/class/ranking/ClassRanking.vue
@@ -3,7 +3,7 @@
         <div v-if="isLoading">
             <loading/>
         </div>
-        <div id="performance" v-else class="margin-bottom-2">
+        <div v-else class="margin-bottom-2">
             <a class="nes-badge center-box margin-bottom-2">
                 <span class="is-warning">Desempenho</span>
             </a>
@@ -32,22 +32,18 @@
                 <progress v-if="scoreBad()" class="nes-progress is-error" value="3" max="10"></progress>
                 <progress v-if="scoreInit()" class="nes-progress is-error" value="0" max="10"></progress>
             </div>
-            <div class="center-button">
-                <audio-button style="margin-top: 10px" :tagId="'performance'" />
-            </div>
         </div>
     </class-wrapper>
 </template>
 
 <script>
 import actionTypes from "@/commons/constants/action-types";
-import AudioButton from "@/commons/components/AudioButton";
 import ClassWrapper from "../commons/ClassWrapper";
 import Loading from "@/commons/components/Loading";
 
 export default {
     name: "class-ranking",
-    components: { AudioButton, ClassWrapper, Loading},
+    components: { ClassWrapper, Loading},
     data() {
         return {
             isLoading: true,

--- a/src/views/internal/student/class/search/ClassSearch.vue
+++ b/src/views/internal/student/class/search/ClassSearch.vue
@@ -3,7 +3,7 @@
         <div v-if="canIShowClasses">
             <class-search-sign-out @signOut="signOut"/>
             <class-search-action @add="add"/>
-            <div id="list-class-student">
+            <div>
                 <div class="margin-bottom-2">
                     <h2 class="title">Minhas classes</h2>
                     <p class="subtitle">Listagem de classes que eu estudo.</p>
@@ -13,21 +13,14 @@
                     v-bind:classValue="item"
                     v-bind:key="item.uid"
                 />
-                <div class="center-button">
-                    <audio-button :tagId="'list-class-student'" />
-                </div>
             </div>
         </div>
         <div v-else-if="canIShowEmptyAlert">
             <class-search-sign-out @signOut="signOut"/>
             <class-search-action @add="add"/>
             <empty
-                id="class-not-found-student"
                 title="Ops, não encontramos nenhuma classe"
                 subtitle="Tente ingressar em uma nova classe por meio no botão abaixo..."/>
-            <div class="center-button">
-                <audio-button :tagId="'class-not-found-student'" />
-            </div>
         </div>
         <div v-else>
             <loading/>
@@ -38,7 +31,6 @@
 <script>
 import {mapMutations} from 'vuex'
 import mutationTypes from "@/commons/constants/mutation-types";
-import AudioButton from "@/commons/components/AudioButton";
 import ClassSearchAction from "./components/ClassSearchAction";
 import ClassSearchCard from "./components/ClassSearchCard";
 import ClassSearchSignOut from "./components/ClassSearchSignOut";
@@ -50,7 +42,7 @@ import actionTypes from "@/commons/constants/action-types";
 
 export default {
     name: "class-search",
-    components: { AudioButton, ClassSearchAction, ClassSearchCard, ClassSearchSignOut, Empty, Loading },
+    components: { ClassSearchAction, ClassSearchCard, ClassSearchSignOut, Empty, Loading },
     data() {
         return {
             user: {},

--- a/src/views/internal/student/exercises/first/ExerciseFirst.vue
+++ b/src/views/internal/student/exercises/first/ExerciseFirst.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="exercise-first" class="container container__full">
+    <div class="container container__full">
         <div id="exercise-one" class="margin-bottom-1 center-text">
             <h2 class="title title--small">Desafio #1 - Mudança de estados físicos da matéria!</h2>
         </div>
@@ -39,7 +39,6 @@
                 <button slot="footer" class="nes-btn is-success full-width" @click="checkPhysicalStatesOrder">{{messageButton}}</button>
                 <button slot="footer" class="nes-btn is-warning margin-top-1 full-width" @click="clear">Reiniciar</button>
                 <button type="button" class="nes-btn is-error margin-top-1 full-width" @click="close">Fechar Desafio</button>
-                <audio-button style="margin-top: 15px" :tagId="'exercise-first'" />
             </div>
         </div>
         <alert id="instructions-alert" title="Instruções" :message="info" :octocat="true" confirmMessage="Confirmar" />
@@ -52,7 +51,6 @@
     import actionTypes from "@/commons/constants/action-types";
     import draggable from "vuedraggable";
     import shuffle from "@/globals/utils/shuffle";
-    import AudioButton from "@/commons/components/AudioButton";
     import Alert from "@/commons/components/Alert";
 
     import ice from "@/assets/images/ice.png"
@@ -61,7 +59,7 @@
 
     export default {
         name: "exercise-first",
-        components: { AudioButton, Alert, draggable },
+        components: { Alert, draggable },
         data() {
             return {
                 answerList: [],

--- a/src/views/internal/student/exercises/first/components/Feedback.vue
+++ b/src/views/internal/student/exercises/first/components/Feedback.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="feedback" class="container container__full">
+    <div class="container container__full">
         <div class="margin-bottom-1">
             <div style="margin-bottom: 15px" class="center-text">
                 <h2 class="title">Feedback Desafio #1</h2>
@@ -15,7 +15,6 @@
                 </section>
             <i class="nes-octocat animate"></i>
             <div style="margin-top: 15px" class="center-button">
-                <audio-button style="margin-bottom: 50px" :tagId="'feedback'" />
                 <button class="nes-btn full-width" @click="backToChallenges">Mais Desafios</button>
             </div>
         </div>
@@ -25,11 +24,10 @@
 
 <script>
     import Alert from "@/commons/components/Alert";
-    import AudioButton from "@/commons/components/AudioButton";
 
     export default {
         name: "feedback",
-        components: { Alert, AudioButton },
+        components: { Alert },
         data() {
             return {
                 info: ''

--- a/src/views/internal/teacher/class/detail/ClassAdd.vue
+++ b/src/views/internal/teacher/class/detail/ClassAdd.vue
@@ -2,11 +2,7 @@
   <section class="container">
     <div class="center-text">
       <h3 class="title">Criar classe</h3>
-      <p
-        id="create-class"
-        class="subtitle"
-      >Para criar uma nova classe, insira as informações da turma nos campos abaixo e confirme.</p>
-      <audio-button :tagId="'create-class'" />
+      <p class="subtitle">Para criar uma nova classe, insira as informações da turma nos campos abaixo e confirme.</p>
     </div>
     <form @submit.prevent="add">
       <class-form-inputs v-model="classValue" />
@@ -19,7 +15,6 @@
 <script>
 import ClassFormInputs from "./components/ClassFormInputs";
 import ClassFormActions from "./components/ClassFormActions";
-import AudioButton from "@/commons/components/AudioButton";
 import Alert from "@/commons/components/Alert";
 
 import firebase from "firebase";
@@ -28,7 +23,7 @@ import getMessageError from "@/globals/utils/getMessageError.js";
 
 export default {
   name: "signup",
-  components: { AudioButton, Alert, ClassFormInputs, ClassFormActions },
+  components: { Alert, ClassFormInputs, ClassFormActions },
   data() {
     return {
       classValue: {

--- a/src/views/internal/teacher/class/detail/ClassView.vue
+++ b/src/views/internal/teacher/class/detail/ClassView.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="container">
         <div class="center-text" v-if="canIShowClass">
-            <div id="class-view" class="margin-bottom-1 center-text">
+            <div class="margin-bottom-1 center-text">
                 <h2 class="title">{{classFound.name}}</h2>
                 <p class="subtitle">{{classFound.description}}</p>
                 <p class="subtitle">Número de estudantes: {{classFound.students.length}}</p>
@@ -12,7 +12,6 @@
                 <span class="is-warning">{{classFound.uid}}</span>
             </div>
             <img class="qr-code-width" alt="QR Code" v-bind:src="qrCodeUrl"/>
-            <audio-button style="margin-bottom: 40px" :tagId="'class-view'" />
             <button style="margin-top: 10px" type="button" class="nes-btn full-width" @click="backToClasses">Voltar</button>
         </div>
         <div v-else>
@@ -22,14 +21,13 @@
 </template>
 
 <script>
-import AudioButton from "@/commons/components/AudioButton";
 import Loading from "@/commons/components/Loading";
 import actionTypes from "@/commons/constants/action-types";
 import QRCode from "qrcode";
 
 export default {
     name: "class-view",
-    components: { AudioButton, Loading },
+    components: { Loading },
     data() {
         return {
             uid: "",

--- a/src/views/internal/teacher/class/search/ClassSearch.vue
+++ b/src/views/internal/teacher/class/search/ClassSearch.vue
@@ -9,8 +9,6 @@
           <p class="subtitle">Listagem de classes que ministro aulas.</p>
         </div>
         <class-search-card v-for="item in classes" v-bind:classValue="item" v-bind:key="item.uid" />
-        <div class="center-button">
-        </div>
       </div>
     </div>
     <div v-else-if="canIShowEmptyAlert">

--- a/src/views/internal/teacher/class/search/ClassSearch.vue
+++ b/src/views/internal/teacher/class/search/ClassSearch.vue
@@ -3,14 +3,13 @@
     <div v-if="canIShowClasses">
       <class-search-sign-out @signOut="signOut"/>
       <class-search-action @add="add" />
-      <div id="list-class-text">
+      <div>
         <div class="margin-bottom-2">
           <h3 class="title">Minhas classes</h3>
           <p class="subtitle">Listagem de classes que ministro aulas.</p>
         </div>
         <class-search-card v-for="item in classes" v-bind:classValue="item" v-bind:key="item.uid" />
         <div class="center-button">
-          <audio-button :tagId="'list-class-text'" />
         </div>
       </div>
     </div>
@@ -18,11 +17,9 @@
       <class-search-sign-out @signOut="signOut"/>
       <class-search-action @add="add" />
       <empty
-        id="text-not-found-class"
         title="Ops, não encontramos nenhuma classe"
         subtitle="Tente criar uma classe e convidar seus alunos..."
       />
-      <audio-button :tagId="'text-not-found-class'" />
     </div>
     <div v-else>
       <loading />
@@ -31,7 +28,6 @@
 </template>
 
 <script>
-import AudioButton from "@/commons/components/AudioButton";
 import ClassSearchAction from "./components/ClassSearchAction";
 import ClassSearchCard from "./components/ClassSearchCard";
 import ClassSearchSignOut from "./components/ClassSearchSignOut";
@@ -44,7 +40,6 @@ import actionTypes from "@/commons/constants/action-types";
 export default {
   name: "class-search",
   components: {
-    AudioButton,
     ClassSearchAction,
     ClassSearchCard,
     ClassSearchSignOut,


### PR DESCRIPTION
Closes #42 

Alterei o ícone do botão de transcrição de textos para áudio:
<img width="380" alt="Screen Shot 2020-04-01 at 21 11 00" src="https://user-images.githubusercontent.com/31314944/78200709-7f9d0980-745d-11ea-987b-58b9ad93c508.png">

Eu pensei em reposicionar este botão para o canto superior direito, ficaria assim:
<img width="380" alt="Screen Shot 2020-04-01 at 21 10 52" src="https://user-images.githubusercontent.com/31314944/78200784-ad824e00-745d-11ea-85fa-95ed13eca935.png">

Não sei se ficaria bom, por isso acabei mantendo a primeira versão.
