### PR TITLE
Correção na renderização das barras de progresso

### DIFF
--- a/src/views/internal/student/class/score/ClassScore.vue
+++ b/src/views/internal/student/class/score/ClassScore.vue
@@ -28,9 +28,9 @@
                 <p style="padding-bottom: 5px"></p>
                 <p style="font-size: 12px; margin-left: 5px">Progresso: ({{points}}/{{MAX_SCORE}})</p>
                 <progress v-if="isInitScore" class="nes-progress" :value="points" :max="MAX_SCORE"></progress>
-                <progress v-if="isGreatScore" class="nes-progress is-success" :value="points" :max="MAX_SCORE"></progress>
-                <progress v-if="isRegularScore" class="nes-progress is-warning" :value="points" :max="MAX_SCORE"></progress>
-                <progress v-if="isBadScore" class="nes-progress is-error" :value="points" :max="MAX_SCORE"></progress>
+                <progress v-else-if="isGreatScore" class="nes-progress is-success" :value="points" :max="MAX_SCORE"></progress>
+                <progress v-else-if="isRegularScore" class="nes-progress is-warning" :value="points" :max="MAX_SCORE"></progress>
+                <progress v-else class="nes-progress is-error" :value="points" :max="MAX_SCORE"></progress>
             </div>
         </div>
     </class-wrapper>
@@ -60,9 +60,6 @@ export default {
     computed: {
         canIShowClass: function () {
             return !this.isLoading;
-        },
-        isBadScore: function () {
-            return ((this.points > 0) && (this.points <= this.MIN_SCORE))
         },
         isGreatScore: function () {
             return this.points === this.MAX_SCORE;

--- a/src/views/internal/student/class/score/ClassScore.vue
+++ b/src/views/internal/student/class/score/ClassScore.vue
@@ -30,7 +30,7 @@
                 <progress v-if="isInitScore" class="nes-progress" :value="points" :max="MAX_SCORE"></progress>
                 <progress v-if="isGreatScore" class="nes-progress is-success" :value="points" :max="MAX_SCORE"></progress>
                 <progress v-if="isRegularScore" class="nes-progress is-warning" :value="points" :max="MAX_SCORE"></progress>
-                <progress v-else class="nes-progress is-error" :value="points" :max="MAX_SCORE"></progress>
+                <progress v-if="isBadScore" class="nes-progress is-error" :value="points" :max="MAX_SCORE"></progress>
             </div>
         </div>
     </class-wrapper>
@@ -60,6 +60,9 @@ export default {
     computed: {
         canIShowClass: function () {
             return !this.isLoading;
+        },
+        isBadScore: function () {
+            return ((this.points > 0) && (this.points <= this.MIN_SCORE))
         },
         isGreatScore: function () {
             return this.points === this.MAX_SCORE;


### PR DESCRIPTION
Correção para o aparecimento de duas barras de progresso na tela de desempenho:
![image](https://user-images.githubusercontent.com/25915025/78960110-70543680-7ac3-11ea-9357-2df2b49dfc9c.png)
